### PR TITLE
Add halt on failure feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ You can override other default settings in your `package.json` by adding the fol
     "repositoryUrl": "https://github.com/mattyboy/istanbul-slack-notify",
     "coverageFiles": ["coverage/coverage-final.json"],
     "username": "coverage-bot",
-    "channel": "#random"
+    "channel": "#random",
+    "haltOnFailure": true
   }
 ```
 

--- a/bin/notify.js
+++ b/bin/notify.js
@@ -52,13 +52,13 @@ const handleResults = () => {
                 if (settings.useTextNotify) {
                     const textNotify = new TextNotify();
                     textNotify.printCoverage(settings.project);
-                    resolve();
+                    resolve(settings);
                 } else {
                     const slack = new SlackNotify(settings.slack);
                     slack.buildCoveragePayload(settings.project)
                         .then(data => {
                             slack.sendNotification(data);
-                            resolve();
+                            resolve(settings);
                         });
                 }
             })
@@ -69,7 +69,7 @@ const handleResults = () => {
 reports
     .generateSummary()
     .then(handleResults)
-    .then(ProcessResponder.respond)
+    .then(settings => ProcessResponder.respond(settings))
     .catch(() => {
         //eslint-disable-next-line no-process-exit
         process.exit(1)

--- a/bin/notify.js
+++ b/bin/notify.js
@@ -19,7 +19,8 @@ const settings = {
     },
     project: {
         projectName: process.env.npm_package_name,
-    }
+    },
+    haltOnFailure: false
 };
 
 // Overwrite settings from package.json if defined
@@ -31,6 +32,7 @@ if (packageJson.coverage) {
     settings.slack.username = packageJson.coverage.username || settings.slack.username;
     settings.project.projectName = packageJson.coverage.projectName || settings.project.projectName || packageJson.name;
     settings.project.repositoryUrl = packageJson.coverage.repositoryUrl;
+    settings.haltOnFailure = packageJson.coverage.hasOwnProperty("haltOnFailure") ? packageJson.coverage.haltOnFailure : settings.haltOnFailure;
 }
 
 const reports = new IstanbulReport(settings.istanbul);
@@ -50,5 +52,6 @@ reports.generateSummary()
                 slack.buildCoveragePayload(settings.project)
                     .then((data) => slack.sendNotification(data));
             }
+            return !coverage.success && settings.haltOnFailure ? 1 : 0;
         })
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-slack-notify",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Sends istanbul / jest coverage summary and git build details to Slack using a pass/fail threshold for project coverage.",
   "main": "./bin/notify.js",
   "scripts": {

--- a/src/process-responder.js
+++ b/src/process-responder.js
@@ -3,9 +3,10 @@ const Promise = require("es6-promise").Promise;
 class ProcessResponder {
     static respond(settings) {
         if (!settings.project.coverage.success && settings.haltOnFailure) {
-            Promise.reject(new Error("Coverage Check Failed & Halt On Failure Set. Exiting."));
-        } else {
-            Promise.resolve(0);
+            return Promise.reject(new Error("Coverage Check Failed & Halt On Failure Set. Exiting."));
         }
-    };
+        return Promise.resolve(0);
+    }
 }
+
+module.exports = ProcessResponder;

--- a/src/process-responder.js
+++ b/src/process-responder.js
@@ -1,0 +1,11 @@
+const Promise = require("es6-promise").Promise;
+
+class ProcessResponder {
+    static respond(settings) {
+        if (!settings.project.coverage.success && settings.haltOnFailure) {
+            Promise.reject(new Error("Coverage Check Failed & Halt On Failure Set. Exiting."));
+        } else {
+            Promise.resolve(0);
+        }
+    };
+}

--- a/test/process-responder.test.js
+++ b/test/process-responder.test.js
@@ -1,0 +1,37 @@
+const ProcessResponder = require("../src/process-responder");
+const {project} = require("./constants");
+
+const failProject = Object.assign(project, {coverage: {success: false}});
+
+test('If coverage fails, but not halt, resolve 0', () => {
+    const settings = Object.assign({haltOnFailure: false}, {project: failProject});
+    return ProcessResponder.respond(settings)
+        .then(result => expect(result)
+            .toBe(0));
+});
+
+test('If coverage fails, and halt is true, reject', () => {
+    const settings = Object.assign({haltOnFailure: true}, {project: failProject});
+    return ProcessResponder.respond(settings)
+        .catch(error => {
+            expect(error)
+                .toBeDefined()
+        })
+});
+
+
+test('If coverage succeeds, and not halt, resolve 0', () => {
+    const settings = Object.assign({haltOnFailure: false}, {project});
+    return ProcessResponder.respond(settings)
+        .then(result => expect(result)
+            .toBe(0));
+});
+
+test('If coverage succeeds, and halt is true, still resolve 0', () => {
+    const settings = Object.assign({haltOnFailure: true}, {project});
+    return ProcessResponder.respond(settings)
+        .catch(error => {
+            expect(error)
+                .toBeDefined()
+        })
+});


### PR DESCRIPTION
Added haltOnFailure optional setting. Process will exit with 1 if coverage fails AND this setting = true

Tests added to cover use cases. 

Has been tested chained with a build script of the form:
`"build:dist": "istanbul-slack-notify && ./devops/build-app.sh dist"`

I've bumped the package.json version from 1.0.19 -> 1.0.20